### PR TITLE
make port configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /var/dynamodb_local
 VOLUME ["/dynamodb_local_db"]
 
 ENV DYNAMODB_VERSION=latest
+ENV DYNAMODB_PORT=8000
 
 ENV JAVA_OPTS=
 
@@ -20,6 +21,4 @@ COPY ./docker-entrypoint.sh /
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
-EXPOSE 8000
-
-CMD ["--sharedDb", "-dbPath", "/dynamodb_local_db", "-port", "8000"]
+CMD ["--sharedDb", "-dbPath", "/dynamodb_local_db"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-exec java -Djava.library.path=. ${JAVA_OPTS} -jar DynamoDBLocal.jar "$@"
+exec java -Djava.library.path=. ${JAVA_OPTS} -jar DynamoDBLocal.jar -port ${DYNAMODB_PORT} "$@"


### PR DESCRIPTION
Example usage:
$ docker run -d -p 8000:443 -e DYNAMODB_PORT=443 cnadiminti/dynamodb-local

Use Case:
When putting this container together with lambda for testing you want
dynamodb to be available at 443 instead of 8000.