### PR TITLE
Use full path in entrypoint

### DIFF
--- a/2016-01-04_1.0/docker-entrypoint.sh
+++ b/2016-01-04_1.0/docker-entrypoint.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-exec java -Djava.library.path=. ${JAVA_OPTS} -jar DynamoDBLocal.jar -port ${DYNAMODB_PORT} "$@"
+exec java -Djava.library.path=/var/dynamodb_local/ ${JAVA_OPTS} -jar /var/dynamodb_local/DynamoDBLocal.jar -port ${DYNAMODB_PORT} "$@"

--- a/2016-01-07_1.0/docker-entrypoint.sh
+++ b/2016-01-07_1.0/docker-entrypoint.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-exec java -Djava.library.path=. ${JAVA_OPTS} -jar DynamoDBLocal.jar -port ${DYNAMODB_PORT} "$@"
+exec java -Djava.library.path=/var/dynamodb_local/ ${JAVA_OPTS} -jar /var/dynamodb_local/DynamoDBLocal.jar -port ${DYNAMODB_PORT} "$@"

--- a/2016-03-01/docker-entrypoint.sh
+++ b/2016-03-01/docker-entrypoint.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-exec java -Djava.library.path=. ${JAVA_OPTS} -jar DynamoDBLocal.jar -port ${DYNAMODB_PORT} "$@"
+exec java -Djava.library.path=/var/dynamodb_local/ ${JAVA_OPTS} -jar /var/dynamodb_local/DynamoDBLocal.jar -port ${DYNAMODB_PORT} "$@"

--- a/2016-04-19/docker-entrypoint.sh
+++ b/2016-04-19/docker-entrypoint.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-exec java -Djava.library.path=. ${JAVA_OPTS} -jar DynamoDBLocal.jar -port ${DYNAMODB_PORT} "$@"
+exec java -Djava.library.path=/var/dynamodb_local/ ${JAVA_OPTS} -jar /var/dynamodb_local/DynamoDBLocal.jar -port ${DYNAMODB_PORT} "$@"

--- a/2016-05-17/docker-entrypoint.sh
+++ b/2016-05-17/docker-entrypoint.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-exec java -Djava.library.path=. ${JAVA_OPTS} -jar DynamoDBLocal.jar -port ${DYNAMODB_PORT} "$@"
+exec java -Djava.library.path=/var/dynamodb_local/ ${JAVA_OPTS} -jar /var/dynamodb_local/DynamoDBLocal.jar -port ${DYNAMODB_PORT} "$@"

--- a/2017-02-16/docker-entrypoint.sh
+++ b/2017-02-16/docker-entrypoint.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-exec java -Djava.library.path=. ${JAVA_OPTS} -jar DynamoDBLocal.jar -port ${DYNAMODB_PORT} "$@"
+exec java -Djava.library.path=/var/dynamodb_local/ ${JAVA_OPTS} -jar /var/dynamodb_local/DynamoDBLocal.jar -port ${DYNAMODB_PORT} "$@"

--- a/2017-04-22_beta/docker-entrypoint.sh
+++ b/2017-04-22_beta/docker-entrypoint.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-exec java -Djava.library.path=. ${JAVA_OPTS} -jar DynamoDBLocal.jar -port ${DYNAMODB_PORT} "$@"
+exec java -Djava.library.path=/var/dynamodb_local/ ${JAVA_OPTS} -jar /var/dynamodb_local/DynamoDBLocal.jar -port ${DYNAMODB_PORT} "$@"

--- a/2018-04-11/docker-entrypoint.sh
+++ b/2018-04-11/docker-entrypoint.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-exec java -Djava.library.path=. ${JAVA_OPTS} -jar DynamoDBLocal.jar -port ${DYNAMODB_PORT} "$@"
+exec java -Djava.library.path=/var/dynamodb_local/ ${JAVA_OPTS} -jar /var/dynamodb_local/DynamoDBLocal.jar -port ${DYNAMODB_PORT} "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-exec java -Djava.library.path=. ${JAVA_OPTS} -jar DynamoDBLocal.jar -port ${DYNAMODB_PORT} "$@"
+exec java -Djava.library.path=/var/dynamodb_local/ ${JAVA_OPTS} -jar /var/dynamodb_local/DynamoDBLocal.jar -port ${DYNAMODB_PORT} "$@"


### PR DESCRIPTION
I use your container for my tests, and was trying to get it working in my Jenkins CI environment to automatically run tests against during builds.
Unfortunately, Jenkins with the Kubernetes plugin overwrites the `WORKDIR` on all containers it spins up, which causes this container to fail because it uses relative paths.
This PR fixes that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cnadiminti/docker-dynamodb-local/9)
<!-- Reviewable:end -->
